### PR TITLE
Add package metadata

### DIFF
--- a/elfeed-dashboard.el
+++ b/elfeed-dashboard.el
@@ -3,7 +3,10 @@
 ;; Copyright (C) 2020  Manoj Kumar Manikchand
 
 ;; Author: Manoj Kumar Manikchand <manojm321@protonmail.com>
+;; URL: https://github.com/Manoj321/elfeed-dashboard
 ;; Keywords: convenience
+;; Package-Requires: ((emacs "25.1")(elfeed "3.3.0"))
+;; Version: 0.0.0
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
This metadata is required for MELPA and straight.el to pull in dependencies.
Good to have if you plan on submitting this package to MELPA.