### PR TITLE
eval-when-compile subr-x

### DIFF
--- a/elfeed-dashboard.el
+++ b/elfeed-dashboard.el
@@ -27,7 +27,7 @@
 ;;; Code:
 (require 'elfeed-search)
 (require 'org-element)
-(require 'subr-x)
+(eval-when-compile (require 'subr-x))
 
 (defvar elfeed-dashboard--elfeed-update-timer nil)
 


### PR DESCRIPTION
Per subr-x.el:
"NB If you want to use this library, it's almost always correct to use:
(eval-when-compile (require 'subr-x))"