### PR TITLE
Make some functions interactive

### DIFF
--- a/elfeed-dashboard.el
+++ b/elfeed-dashboard.el
@@ -73,6 +73,7 @@
 
 (defun elfeed-dashboard-update ()
   "Fetch new feeds, Optionally try reading `elfeed-org' configuration."
+  (interactive)
   (if (fboundp 'elfeed-org)
       (elfeed-org))
   (unless elfeed-dashboard--elfeed-update-timer
@@ -146,6 +147,7 @@ trimmed and the last digit will be replace with +"
 
 (defun elfeed-dashboard-update-links (&rest _)
   "Update content of all links."
+  (interactive)
   (with-current-buffer elfeed-dashboard--buf
     (org-element-map (org-element-parse-buffer) 'link
       (lambda (link)


### PR DESCRIPTION
These functions seems to be commands that can be invoked interactively. In addition, it makes life easier for people who define keybindings outside `elfeed-dashboard-parse-keymap`.