### PR TITLE
Make use-package call more idiomatic

### DIFF
--- a/README.org
+++ b/README.org
@@ -20,10 +20,10 @@
    #+begin_src emacs-lisp
      (use-package elfeed-dashboard
        :ensure t
-       :config (progn
-                 (setq elfeed-dashboard-file "~/elfeed-dashboard.org")
-                  ;; update feed counts on elfeed-quit
-                 (advice-add 'elfeed-search-quit-window :after #'elfeed-dashboard-update-links)))
+       :config
+       (setq elfeed-dashboard-file "~/elfeed-dashboard.org")
+       ;; update feed counts on elfeed-quit
+       (advice-add 'elfeed-search-quit-window :after #'elfeed-dashboard-update-links))
    #+end_src
 
 ** Direct
@@ -32,10 +32,10 @@
    #+begin_src emacs-lisp
      (use-package elfeed-dashboard
        :load-path "~/.emacs.d/lisp/elfeed-dashboard/"
-       :config (progn
-                 (setq elfeed-dashboard-file "~/.emacs.d/lisp/elfeed-dashboard/elfeed-dashboard.org")
-                  ;; update feed counts on elfeed-quit
-                 (advice-add 'elfeed-search-quit-window :after #'elfeed-dashboard-update-links)))
+       :config
+       (setq elfeed-dashboard-file "~/.emacs.d/lisp/elfeed-dashboard/elfeed-dashboard.org")
+       ;; update feed counts on elfeed-quit
+       (advice-add 'elfeed-search-quit-window :after #'elfeed-dashboard-update-links))
    #+end_src
 
 * Usage


### PR DESCRIPTION
For `use-package`, no `progn` needed after `:init` or `:config`.